### PR TITLE
Fix round advancement off-by-one

### DIFF
--- a/app/rounds/page.tsx
+++ b/app/rounds/page.tsx
@@ -246,10 +246,11 @@ export default function RoundsPage() {
     if (!tournament || !canAdvanceRound()) return
 
     const nextRound = tournament.currentRound + 1
+    const isCompleted = nextRound > tournament.rounds
     const updatedTournament = {
       ...tournament,
-      currentRound: nextRound,
-      status: nextRound > tournament.rounds ? ("completed" as const) : tournament.status,
+      currentRound: isCompleted ? tournament.rounds : nextRound,
+      status: isCompleted ? ("completed" as const) : tournament.status,
       roundStartTime: undefined,
     }
 


### PR DESCRIPTION
## Summary
- ensure round advancement doesn't exceed tournament limits

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685998a27f8c832d86222231bf55ca4e