### PR TITLE
Fix ESLint extends config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,8 +11,8 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.config({
-    extends: "next/core-web-vitals", "next/typescript",
-        rules: {
+    extends: ["next/core-web-vitals", "next/typescript"],
+    rules: {
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },


### PR DESCRIPTION
## Summary
- fix ESLint config `extends` to use array syntax

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599a6c1b24832db85d1e77f9e5d262