### PR TITLE
Update README with Inter font info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load the [Inter](https://fonts.google.com/specimen/Inter) font.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- update README to note that Inter font is loaded with `next/font`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599a71de34832db860b25f131166b8