### PR TITLE
Add jest and pairing tests

### DIFF
--- a/__tests__/pairings.test.ts
+++ b/__tests__/pairings.test.ts
@@ -1,0 +1,66 @@
+import { generateSwissPairings, Player, Match } from '../lib/pairings'
+
+describe('generateSwissPairings', () => {
+  const basePlayer = {
+    points: 0,
+    matchWins: 0,
+    matchLosses: 0,
+    matchDraws: 0,
+    gameWins: 0,
+    gameLosses: 0,
+    opponentIds: [],
+  }
+
+  test('first round pairs players randomly', () => {
+    const players: Player[] = [
+      { id: '1', nickname: 'P1', ...basePlayer },
+      { id: '2', nickname: 'P2', ...basePlayer },
+      { id: '3', nickname: 'P3', ...basePlayer },
+      { id: '4', nickname: 'P4', ...basePlayer },
+    ]
+
+    const pairings = generateSwissPairings(players, 1, [])
+    expect(pairings.length).toBe(2)
+
+    const ids = pairings.flatMap(p => p.isBye ? [p.player1Id] : [p.player1Id, p.player2Id])
+    expect(new Set(ids).size).toBe(4)
+  })
+
+  test('later rounds avoid repeated opponents', () => {
+    const players: Player[] = [
+      { id: '1', nickname: 'P1', points: 3, matchWins: 1, matchLosses: 0, matchDraws: 0, gameWins: 0, gameLosses: 0, opponentIds: ['2'] },
+      { id: '2', nickname: 'P2', points: 0, matchWins: 0, matchLosses: 1, matchDraws: 0, gameWins: 0, gameLosses: 0, opponentIds: ['1'] },
+      { id: '3', nickname: 'P3', points: 3, matchWins: 1, matchLosses: 0, matchDraws: 0, gameWins: 0, gameLosses: 0, opponentIds: ['4'] },
+      { id: '4', nickname: 'P4', points: 0, matchWins: 0, matchLosses: 1, matchDraws: 0, gameWins: 0, gameLosses: 0, opponentIds: ['3'] },
+    ]
+
+    const existingMatches: Match[] = [
+      { id: '1-1', round: 1, player1Id: '1', player2Id: '2' },
+      { id: '1-2', round: 1, player1Id: '3', player2Id: '4' },
+    ]
+
+    const pairings = generateSwissPairings(players, 2, existingMatches)
+    expect(pairings.length).toBe(2)
+    pairings.forEach(pair => {
+      const repeated = existingMatches.some(
+        m =>
+          (m.player1Id === pair.player1Id && m.player2Id === pair.player2Id) ||
+          (m.player1Id === pair.player2Id && m.player2Id === pair.player1Id)
+      )
+      expect(repeated).toBe(false)
+    })
+  })
+
+  test('assigns bye when odd number of players', () => {
+    const players: Player[] = [
+      { id: '1', nickname: 'P1', ...basePlayer },
+      { id: '2', nickname: 'P2', ...basePlayer },
+      { id: '3', nickname: 'P3', ...basePlayer },
+    ]
+
+    const pairings = generateSwissPairings(players, 1, [])
+    const byes = pairings.filter(p => p.isBye)
+    expect(byes.length).toBe(1)
+    expect(byes[0].player1Id).toBeDefined()
+  })
+})

--- a/app/rounds/page.tsx
+++ b/app/rounds/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ArrowLeft, Play, Clock, Trophy } from "lucide-react"
 import Link from "next/link"
+import { generateSwissPairings, Player, Match } from "@/lib/pairings"
 
 interface Tournament {
   id: string
@@ -18,28 +19,6 @@ interface Tournament {
   matches: Match[]
   timePerRound: number
   roundStartTime?: number
-}
-
-interface Player {
-  id: string
-  nickname: string
-  points: number
-  matchWins: number
-  matchLosses: number
-  matchDraws: number
-  gameWins: number
-  gameLosses: number
-  opponentIds: string[]
-}
-
-interface Match {
-  id: string
-  round: number
-  player1Id: string
-  player2Id: string
-  result?: "player1" | "player2" | "draw"
-  gameResults?: ("player1" | "player2")[]
-  isBye?: boolean
 }
 
 export default function RoundsPage() {
@@ -57,106 +36,6 @@ export default function RoundsPage() {
     localStorage.setItem("tournament", JSON.stringify(updatedTournament))
   }
 
-  const generateSwissPairings = (players: Player[], round: number, existingMatches: Match[]): Match[] => {
-    // Sort players by points (descending), then by tiebreakers
-    const sortedPlayers = [...players].sort((a, b) => {
-      if (a.points !== b.points) return b.points - a.points
-      return b.matchWins - a.matchWins
-    })
-
-    const pairings: Match[] = []
-    const paired = new Set<string>()
-
-    // For first round, pair randomly
-    if (round === 1) {
-      const shuffled = [...sortedPlayers].sort(() => Math.random() - 0.5)
-      for (let i = 0; i < shuffled.length - 1; i += 2) {
-        pairings.push({
-          id: `${round}-${i / 2 + 1}`,
-          round,
-          player1Id: shuffled[i].id,
-          player2Id: shuffled[i + 1].id,
-        })
-      }
-
-      // Handle bye if odd number of players
-      if (shuffled.length % 2 === 1) {
-        pairings.push({
-          id: `${round}-bye`,
-          round,
-          player1Id: shuffled[shuffled.length - 1].id,
-          player2Id: "",
-          isBye: true,
-          result: "player1",
-        })
-      }
-
-      return pairings
-    }
-
-    // Swiss pairing for subsequent rounds
-    for (let i = 0; i < sortedPlayers.length; i++) {
-      const player1 = sortedPlayers[i]
-      if (paired.has(player1.id)) continue
-
-      let paired_player = null
-
-      // Find best opponent (similar points, haven't played before)
-      for (let j = i + 1; j < sortedPlayers.length; j++) {
-        const player2 = sortedPlayers[j]
-        if (paired.has(player2.id)) continue
-
-        // Check if they've played before
-        const hasPlayed = existingMatches.some(
-          (match) =>
-            (match.player1Id === player1.id && match.player2Id === player2.id) ||
-            (match.player1Id === player2.id && match.player2Id === player1.id),
-        )
-
-        if (!hasPlayed) {
-          paired_player = player2
-          break
-        }
-      }
-
-      // If no valid opponent found, pair with closest available
-      if (!paired_player) {
-        for (let j = i + 1; j < sortedPlayers.length; j++) {
-          const player2 = sortedPlayers[j]
-          if (!paired.has(player2.id)) {
-            paired_player = player2
-            break
-          }
-        }
-      }
-
-      if (paired_player) {
-        pairings.push({
-          id: `${round}-${pairings.length + 1}`,
-          round,
-          player1Id: player1.id,
-          player2Id: paired_player.id,
-        })
-        paired.add(player1.id)
-        paired.add(paired_player.id)
-      }
-    }
-
-    // Handle bye if odd number of players
-    const unpairedPlayer = sortedPlayers.find((p) => !paired.has(p.id))
-    if (unpairedPlayer) {
-      pairings.push({
-        id: `${round}-bye`,
-        round,
-        player1Id: unpairedPlayer.id,
-        player2Id: "",
-        isBye: true,
-        result: "player1",
-      })
-    }
-
-    return pairings
-  }
 
   const startRound = () => {
     if (!tournament) return

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/lib/pairings.ts
+++ b/lib/pairings.ts
@@ -1,0 +1,122 @@
+export interface Player {
+  id: string
+  nickname: string
+  points: number
+  matchWins: number
+  matchLosses: number
+  matchDraws: number
+  gameWins: number
+  gameLosses: number
+  opponentIds: string[]
+}
+
+export interface Match {
+  id: string
+  round: number
+  player1Id: string
+  player2Id: string
+  result?: "player1" | "player2" | "draw"
+  gameResults?: ("player1" | "player2")[]
+  isBye?: boolean
+}
+
+export function generateSwissPairings(players: Player[], round: number, existingMatches: Match[]): Match[] {
+  // Sort players by points (descending), then by tiebreakers
+  const sortedPlayers = [...players].sort((a, b) => {
+    if (a.points !== b.points) return b.points - a.points
+    return b.matchWins - a.matchWins
+  })
+
+  const pairings: Match[] = []
+  const paired = new Set<string>()
+
+  // For first round, pair randomly
+  if (round === 1) {
+    const shuffled = [...sortedPlayers].sort(() => Math.random() - 0.5)
+    for (let i = 0; i < shuffled.length - 1; i += 2) {
+      pairings.push({
+        id: `${round}-${i / 2 + 1}`,
+        round,
+        player1Id: shuffled[i].id,
+        player2Id: shuffled[i + 1].id,
+      })
+    }
+
+    // Handle bye if odd number of players
+    if (shuffled.length % 2 === 1) {
+      pairings.push({
+        id: `${round}-bye`,
+        round,
+        player1Id: shuffled[shuffled.length - 1].id,
+        player2Id: "",
+        isBye: true,
+        result: "player1",
+      })
+    }
+
+    return pairings
+  }
+
+  // Swiss pairing for subsequent rounds
+  for (let i = 0; i < sortedPlayers.length; i++) {
+    const player1 = sortedPlayers[i]
+    if (paired.has(player1.id)) continue
+
+    let paired_player: Player | null = null
+
+    // Find best opponent (similar points, haven't played before)
+    for (let j = i + 1; j < sortedPlayers.length; j++) {
+      const player2 = sortedPlayers[j]
+      if (paired.has(player2.id)) continue
+
+      // Check if they've played before
+      const hasPlayed = existingMatches.some(
+        (match) =>
+          (match.player1Id === player1.id && match.player2Id === player2.id) ||
+          (match.player1Id === player2.id && match.player2Id === player1.id),
+      )
+
+      if (!hasPlayed) {
+        paired_player = player2
+        break
+      }
+    }
+
+    // If no valid opponent found, pair with closest available
+    if (!paired_player) {
+      for (let j = i + 1; j < sortedPlayers.length; j++) {
+        const player2 = sortedPlayers[j]
+        if (!paired.has(player2.id)) {
+          paired_player = player2
+          break
+        }
+      }
+    }
+
+    if (paired_player) {
+      pairings.push({
+        id: `${round}-${pairings.length + 1}`,
+        round,
+        player1Id: player1.id,
+        player2Id: paired_player.id,
+      })
+      paired.add(player1.id)
+      paired.add(paired_player.id)
+    }
+  }
+
+  // Handle bye if odd number of players
+  const unpairedPlayer = sortedPlayers.find((p) => !paired.has(p.id))
+  if (unpairedPlayer) {
+    pairings.push({
+      id: `${round}-bye`,
+      round,
+      player1Id: unpairedPlayer.id,
+      player2Id: "",
+      isBye: true,
+      result: "player1",
+    })
+  }
+
+  return pairings
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
@@ -32,6 +33,10 @@
     "eslint-config-next": "15.2.4",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.0.0",
+    "@testing-library/react": "^14.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- extract Swiss pairing logic to `lib/pairings.ts`
- import the helper in rounds page
- add Jest configuration and basic pairing tests
- declare Jest and Testing Library dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599a75f808832dae76174ba5014fe8