### PR TITLE
Add SQLite persistence

### DIFF
--- a/app/api/tournament/route.ts
+++ b/app/api/tournament/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import db from '@/lib/db'
+
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.searchParams.get('id') || 'current'
+  const row = db.prepare('SELECT data FROM tournaments WHERE id = ?').get(id)
+  if (!row) {
+    return NextResponse.json({ message: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(JSON.parse(row.data))
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const id = body.id || 'current'
+  const data = JSON.stringify(body)
+  db.prepare('INSERT OR REPLACE INTO tournaments (id, data) VALUES (?, ?)').run(
+    id,
+    data,
+  )
+  return NextResponse.json({ status: 'ok' })
+}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -52,10 +52,11 @@ export default function LeaderboardPage() {
   const [tournament, setTournament] = useState<Tournament | null>(null)
 
   useEffect(() => {
-    const savedTournament = localStorage.getItem("tournament")
-    if (savedTournament) {
-      setTournament(JSON.parse(savedTournament))
-    }
+    fetch("/api/tournament")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) setTournament(data)
+      })
   }, [])
 
   const calculateTiebreakers = (players: Player[], matches: Match[]): PlayerWithTiebreakers[] => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,11 +46,11 @@ export default function HomePage() {
   const [timeRemaining, setTimeRemaining] = useState<number>(0)
 
   useEffect(() => {
-    // Load tournament from localStorage
-    const savedTournament = localStorage.getItem("tournament")
-    if (savedTournament) {
-      setTournament(JSON.parse(savedTournament))
-    }
+    fetch("/api/tournament")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) setTournament(data)
+      })
   }, [])
 
   useEffect(() => {

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -50,17 +50,24 @@ export default function PlayersPage() {
   const [newPlayerName, setNewPlayerName] = useState("")
 
   useEffect(() => {
-    const savedTournament = localStorage.getItem("tournament")
-    if (savedTournament) {
-      setTournament(JSON.parse(savedTournament))
-    } else {
-      router.push("/setup")
-    }
+    fetch("/api/tournament")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          setTournament(data)
+        } else {
+          router.push("/setup")
+        }
+      })
   }, [router])
 
   const saveTournament = (updatedTournament: Tournament) => {
     setTournament(updatedTournament)
-    localStorage.setItem("tournament", JSON.stringify(updatedTournament))
+    fetch("/api/tournament", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(updatedTournament),
+    })
   }
 
   const addPlayer = () => {

--- a/app/rounds/page.tsx
+++ b/app/rounds/page.tsx
@@ -25,15 +25,22 @@ export default function RoundsPage() {
   const [tournament, setTournament] = useState<Tournament | null>(null)
 
   useEffect(() => {
-    const savedTournament = localStorage.getItem("tournament")
-    if (savedTournament) {
-      setTournament(JSON.parse(savedTournament))
-    }
+    fetch("/api/tournament")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          setTournament(data)
+        }
+      })
   }, [])
 
   const saveTournament = (updatedTournament: Tournament) => {
     setTournament(updatedTournament)
-    localStorage.setItem("tournament", JSON.stringify(updatedTournament))
+    fetch("/api/tournament", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(updatedTournament),
+    })
   }
 
 

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -64,8 +64,13 @@ export default function SetupPage() {
       timePerRound: Number.parseInt(timePerRound),
     }
 
-    localStorage.setItem("tournament", JSON.stringify(tournament))
-    router.push("/players")
+    fetch("/api/tournament", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(tournament),
+    }).then(() => {
+      router.push("/players")
+    })
   }
 
   return (

--- a/app/timer/page.tsx
+++ b/app/timer/page.tsx
@@ -43,23 +43,25 @@ export default function TimerPage() {
   const [isPaused, setIsPaused] = useState(false);
 
   useEffect(() => {
-    const savedTournament = localStorage.getItem("tournament");
-    if (savedTournament) {
-      const parsed = JSON.parse(savedTournament);
-      setTournament(parsed);
+    fetch("/api/tournament")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((parsed) => {
+        if (parsed) {
+          setTournament(parsed);
 
-      if (parsed.roundStartTime) {
-        const elapsed = Date.now() - parsed.roundStartTime;
-        const remaining = Math.max(
-          0,
-          parsed.timePerRound * 60 * 1000 - elapsed
-        );
-        setTimeRemaining(remaining);
-        setIsRunning(remaining > 0);
-      } else {
-        setTimeRemaining(parsed.timePerRound * 60 * 1000);
-      }
-    }
+          if (parsed.roundStartTime) {
+            const elapsed = Date.now() - parsed.roundStartTime;
+            const remaining = Math.max(
+              0,
+              parsed.timePerRound * 60 * 1000 - elapsed
+            );
+            setTimeRemaining(remaining);
+            setIsRunning(remaining > 0);
+          } else {
+            setTimeRemaining(parsed.timePerRound * 60 * 1000);
+          }
+        }
+      });
   }, []);
 
   useEffect(() => {

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -57,10 +57,11 @@ export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false)
 
   useEffect(() => {
-    const savedTournament = localStorage.getItem("tournament")
-    if (savedTournament) {
-      setTournament(JSON.parse(savedTournament))
-    }
+    fetch("/api/tournament")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) setTournament(data)
+      })
   }, [pathname]) // Re-check when route changes
 
   const NavItems = ({ mobile = false }) => (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,13 @@
+export async function fetchTournament() {
+  const res = await fetch('/api/tournament')
+  if (!res.ok) return null
+  return res.json()
+}
+
+export async function saveTournament(tournament: any) {
+  await fetch('/api/tournament', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(tournament),
+  })
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,14 @@
+import Database from 'better-sqlite3'
+
+const db = new Database('tournament.db')
+
+db.pragma('journal_mode = WAL')
+
+db.prepare(
+  `CREATE TABLE IF NOT EXISTS tournaments (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL
+  )`
+).run()
+
+export default db

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "better-sqlite3": "^9"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- store tournament data in SQLite instead of localStorage
- add API route to read/write tournament JSON
- update UI pages to fetch/save using the new API
- manage SQLite DB with better-sqlite3

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599c1bc63c832d9097c9c6994160bb