### PR TITLE
Remove testing library causing build conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "tw-animate-css": "^1.3.4",
     "typescript": "^5",
     "jest": "^29.0.0",
-    "@testing-library/react": "^14.0.0",
     "ts-jest": "^29.0.0",
     "@types/jest": "^29.0.0"
   }


### PR DESCRIPTION
## Summary
- fix React 19 dependency conflict by dropping `@testing-library/react`

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68599e64edc0832db41bcc7fb1a333e9