### PR TITLE
Add tournament history and CSV export

### DIFF
--- a/app/api/tournaments/route.ts
+++ b/app/api/tournaments/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import db from '@/lib/db'
+
+export async function GET() {
+  const rows = db.prepare('SELECT id, data FROM tournaments ORDER BY id DESC').all()
+  const tournaments = rows.map((row: any) => {
+    const t = JSON.parse(row.data)
+    return {
+      id: row.id,
+      name: t.name,
+      status: t.status,
+      rounds: t.rounds,
+      currentRound: t.currentRound,
+      players: t.players.length,
+      matches: t.matches.length,
+    }
+  })
+  return NextResponse.json(tournaments)
+}

--- a/app/history/[id]/page.tsx
+++ b/app/history/[id]/page.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { useParams } from "next/navigation"
+import Link from "next/link"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { Download, ArrowLeft } from "lucide-react"
+
+interface Player {
+  id: string
+  nickname: string
+}
+
+interface Match {
+  id: string
+  round: number
+  player1Id: string
+  player2Id: string
+  result?: "player1" | "player2" | "draw"
+  isBye?: boolean
+}
+
+interface Tournament {
+  id: string
+  name: string
+  rounds: number
+  currentRound: number
+  status: "setup" | "active" | "completed"
+  players: Player[]
+  matches: Match[]
+  timePerRound: number
+}
+
+export default function TournamentHistoryPage() {
+  const params = useParams()
+  const id = params.id as string
+  const [tournament, setTournament] = useState<Tournament | null>(null)
+
+  useEffect(() => {
+    fetch(`/api/tournament?id=${id}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setTournament(data))
+  }, [id])
+
+  const getPlayerName = (playerId: string) => {
+    return tournament?.players.find((p) => p.id === playerId)?.nickname || "Unknown"
+  }
+
+  const exportMatches = () => {
+    if (!tournament) return
+    const headers = ["Round", "Player 1", "Player 2", "Result"]
+    const rows = tournament.matches.map((m) => {
+      const result = m.isBye
+        ? "Bye"
+        : m.result === "draw"
+          ? "Draw"
+          : m.result
+          ? `${getPlayerName(m.result === "player1" ? m.player1Id : m.player2Id)} Wins`
+          : ""
+      return [
+        m.round.toString(),
+        getPlayerName(m.player1Id),
+        m.isBye ? "BYE" : getPlayerName(m.player2Id),
+        result,
+      ]
+    })
+    const csv = [headers, ...rows]
+      .map((row) => row.map((cell) => `"${cell}"`).join(","))
+      .join("\n")
+    const blob = new Blob([csv], { type: "text/csv" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `${tournament.name}_matches.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  if (!tournament) {
+    return <div className="p-6">Loading...</div>
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <div className="flex items-center justify-between max-w-4xl mx-auto">
+        <div className="flex items-center space-x-4">
+          <Link href="/history">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-3xl font-bold">Match History</h1>
+            <p className="text-muted-foreground">{tournament.name}</p>
+          </div>
+        </div>
+        <Button onClick={exportMatches} variant="outline">
+          <Download className="mr-2 h-4 w-4" /> Export CSV
+        </Button>
+      </div>
+
+      <div className="max-w-4xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle>Matches</CardTitle>
+            <CardDescription>All recorded matches</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Round</TableHead>
+                  <TableHead>Player 1</TableHead>
+                  <TableHead>Player 2</TableHead>
+                  <TableHead>Result</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {tournament.matches.map((m) => (
+                  <TableRow key={m.id}>
+                    <TableCell>{m.round}</TableCell>
+                    <TableCell>{getPlayerName(m.player1Id)}</TableCell>
+                    <TableCell>{m.isBye ? "BYE" : getPlayerName(m.player2Id)}</TableCell>
+                    <TableCell>
+                      {m.isBye
+                        ? "Bye"
+                        : m.result === "draw"
+                        ? "Draw"
+                        : m.result
+                        ? `${getPlayerName(m.result === "player1" ? m.player1Id : m.player2Id)} Wins`
+                        : ""}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import Link from "next/link"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+
+interface TournamentSummary {
+  id: string
+  name: string
+  status: string
+  rounds: number
+  currentRound: number
+  players: number
+  matches: number
+}
+
+export default function HistoryPage() {
+  const [tournaments, setTournaments] = useState<TournamentSummary[]>([])
+
+  useEffect(() => {
+    fetch("/api/tournaments")
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setTournaments(data))
+  }, [])
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="max-w-4xl mx-auto">
+        <Card>
+          <CardHeader>
+            <CardTitle>Tournament Archive</CardTitle>
+            <CardDescription>Past tournaments and ongoing records</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {tournaments.length === 0 ? (
+              <div className="text-center text-muted-foreground">No tournaments found.</div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-center">Players</TableHead>
+                    <TableHead className="text-center">Rounds</TableHead>
+                    <TableHead className="text-center">Matches</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {tournaments.map((t) => (
+                    <TableRow key={t.id}>
+                      <TableCell>{t.name}</TableCell>
+                      <TableCell>{t.status}</TableCell>
+                      <TableCell className="text-center">{t.players}</TableCell>
+                      <TableCell className="text-center">{t.rounds}</TableCell>
+                      <TableCell className="text-center">{t.matches}</TableCell>
+                      <TableCell className="text-right">
+                        <Link href={`/history/${t.id}`}>
+                          <Button size="sm" variant="outline">View</Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -6,7 +6,7 @@ import { usePathname } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import { Home, Users, Play, Trophy, Clock, Settings, Menu, Gamepad2 } from "lucide-react"
+import { Home, Users, Play, Trophy, Clock, Settings, Menu, Gamepad2, History } from "lucide-react"
 
 interface Tournament {
   id: string
@@ -48,6 +48,7 @@ const navigationItems = [
   { href: "/rounds", label: "Rounds", icon: Play },
   { href: "/leaderboard", label: "Leaderboard", icon: Trophy },
   { href: "/timer", label: "Timer", icon: Clock },
+  { href: "/history", label: "History", icon: History },
   { href: "/setup", label: "Setup", icon: Settings },
 ]
 


### PR DESCRIPTION
## Summary
- expose a `/api/tournaments` endpoint that lists tournaments
- add a History nav item
- implement archive page showing past tournaments
- add match history page with CSV export

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68599de7aa10832d9ed3bcea91081f09