### PR TITLE
Implement continue prompt and active tournament tracking

### DIFF
--- a/app/api/tournament/route.ts
+++ b/app/api/tournament/route.ts
@@ -3,11 +3,30 @@ import db from '@/lib/db'
 
 export async function GET(req: NextRequest) {
   const id = req.nextUrl.searchParams.get('id') || 'current'
-  const row = db.prepare('SELECT data FROM tournaments WHERE id = ?').get(id)
+  let row = db.prepare('SELECT data FROM tournaments WHERE id = ?').get(id)
+
   if (!row) {
     return NextResponse.json({ message: 'Not found' }, { status: 404 })
   }
-  return NextResponse.json(JSON.parse(row.data))
+
+  let data = JSON.parse(row.data)
+
+  // If the "current" row stores only the active id, resolve it
+  if (
+    id === 'current' &&
+    data &&
+    typeof data === 'object' &&
+    data.id &&
+    !data.status
+  ) {
+    row = db.prepare('SELECT data FROM tournaments WHERE id = ?').get(data.id)
+    if (!row) {
+      return NextResponse.json({ message: 'Not found' }, { status: 404 })
+    }
+    data = JSON.parse(row.data)
+  }
+
+  return NextResponse.json(data)
 }
 
 export async function POST(req: NextRequest) {
@@ -18,5 +37,12 @@ export async function POST(req: NextRequest) {
     id,
     data,
   )
+  // Track the active tournament
+  if (id !== 'current') {
+    db.prepare('INSERT OR REPLACE INTO tournaments (id, data) VALUES (?, ?)').run(
+      'current',
+      JSON.stringify({ id }),
+    )
+  }
   return NextResponse.json({ status: 'ok' })
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,12 +44,16 @@ interface Match {
 export default function HomePage() {
   const [tournament, setTournament] = useState<Tournament | null>(null)
   const [timeRemaining, setTimeRemaining] = useState<number>(0)
+  const [showPrompt, setShowPrompt] = useState(false)
 
   useEffect(() => {
-    fetch("/api/tournament")
+    fetch("/api/tournament?id=current")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (data) setTournament(data)
+        if (data) {
+          setTournament(data)
+          setShowPrompt(true)
+        }
       })
   }, [])
 
@@ -82,7 +86,7 @@ export default function HomePage() {
       .slice(0, 3)
   }
 
-  if (!tournament) {
+  if (!tournament && !showPrompt) {
     return (
       <div className="container mx-auto p-6">
         <div className="text-center space-y-6">
@@ -101,6 +105,38 @@ export default function HomePage() {
                 <Button className="w-full" size="lg">
                   <Settings className="mr-2 h-4 w-4" />
                   Create Tournament
+                </Button>
+              </Link>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    )
+  }
+
+  if (showPrompt && tournament) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="text-center space-y-6">
+          <div className="space-y-2">
+            <h1 className="text-4xl font-bold">TCG Tournament Manager</h1>
+            <p className="text-xl text-muted-foreground">Fast Swiss System Tournaments</p>
+          </div>
+
+          <Card className="max-w-md mx-auto">
+            <CardHeader>
+              <CardTitle>Resume Tournament</CardTitle>
+              <CardDescription>Continue the current event or start a new one</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Button className="w-full" size="lg" onClick={() => setShowPrompt(false)}>
+                <Play className="mr-2 h-4 w-4" />
+                Continue "{tournament.name}"
+              </Button>
+              <Link href="/setup">
+                <Button variant="outline" className="w-full" size="lg">
+                  <Settings className="mr-2 h-4 w-4" />
+                  New Tournament
                 </Button>
               </Link>
             </CardContent>


### PR DESCRIPTION
## Summary
- add current tournament pointer logic in API
- save active tournament id whenever a tournament is posted
- check `/api/tournament?id=current` on home page
- prompt to resume current tournament or start a new one

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a0a27f64832db9790cb44cbead17