### PR TITLE
Enable WAL mode in SQLite

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,7 +2,8 @@ import Database from 'better-sqlite3'
 
 const db = new Database('tournament.db')
 
-db.pragma('journal_mode = WAL')
+// Use Write-Ahead Logging to avoid database locking issues
+db.prepare('PRAGMA journal_mode = WAL').run()
 
 db.prepare(
   `CREATE TABLE IF NOT EXISTS tournaments (


### PR DESCRIPTION
## Summary
- set SQLite journal mode to WAL using `db.prepare('PRAGMA journal_mode = WAL').run()`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a6aec9d8832d98f5a90ad1ee44d2