### PR TITLE
Enable player suggestions

### DIFF
--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import db from '@/lib/db'
+
+export async function GET() {
+  const rows = db
+    .prepare('SELECT data FROM tournaments WHERE id != ?')
+    .all('current')
+  const names = new Set<string>()
+  rows.forEach((row: any) => {
+    try {
+      const data = JSON.parse(row.data)
+      if (Array.isArray(data.players)) {
+        for (const p of data.players) {
+          if (p && p.nickname) names.add(p.nickname)
+        }
+      }
+    } catch (err) {
+      // ignore malformed rows
+    }
+  })
+  return NextResponse.json(Array.from(names))
+}

--- a/app/players/page.tsx
+++ b/app/players/page.tsx
@@ -59,6 +59,7 @@ export default function PlayersPage() {
   const [editedName, setEditedName] = useState("")
   const [searchTerm, setSearchTerm] = useState("");
   const debouncedSearch = useDebounce(searchTerm, 300);
+  const [knownPlayers, setKnownPlayers] = useState<string[]>([])
 
   useEffect(() => {
     fetch("/api/tournament")
@@ -71,6 +72,12 @@ export default function PlayersPage() {
         }
       });
   }, [router]);
+
+  useEffect(() => {
+    fetch("/api/players")
+      .then((res) => (res.ok ? res.json() : []))
+      .then((data) => setKnownPlayers(data));
+  }, []);
 
   const saveTournament = (updatedTournament: Tournament) => {
     setTournament(updatedTournament);
@@ -278,11 +285,21 @@ export default function PlayersPage() {
                   <Label htmlFor="player-name">Player Nickname</Label>
                   <Input
                     id="player-name"
+                    list="player-suggestions"
                     placeholder="Enter nickname"
                     value={newPlayerName}
                     onChange={(e) => setNewPlayerName(e.target.value)}
                     onKeyPress={(e) => e.key === "Enter" && addPlayer()}
                   />
+                  <datalist id="player-suggestions">
+                    {knownPlayers
+                      .filter((n) =>
+                        n.toLowerCase().includes(newPlayerName.toLowerCase()),
+                      )
+                      .map((name) => (
+                        <option key={name} value={name} />
+                      ))}
+                  </datalist>
                 </div>
                 <Button
                   onClick={addPlayer}


### PR DESCRIPTION
## Summary
- add `/api/players` endpoint to list unique players from stored tournaments
- show suggestions when adding players so previously used names can be reused

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859adc432fc832dacd7348e58c56058