### PR TITLE
Fix tournament render logic

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -152,39 +152,37 @@ export default function HomePage() {
 
   return (
     <div className="container mx-auto p-6 space-y-6">
-      {tournament !== null && (
-      <>
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-3xl font-bold">{tournament.name}</h1>
-            <p className="text-muted-foreground">
-              Round {tournament.currentRound} of {tournament.rounds}
-            </p>
-          </div>
-          <Badge variant={tournament.status === "active" ? "default" : "secondary"}>
-            {tournament.status.charAt(0).toUpperCase() + tournament.status.slice(1)}
-          </Badge>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">{tournament!.name}</h1>
+          <p className="text-muted-foreground">
+            Round {tournament!.currentRound} of {tournament!.rounds}
+          </p>
         </div>
+        <Badge variant={tournament!.status === "active" ? "default" : "secondary"}>
+          {tournament!.status.charAt(0).toUpperCase() + tournament!.status.slice(1)}
+        </Badge>
+      </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Players</CardTitle>
-              <Users className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{tournament.players.length}</div>
-            </CardContent>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Players</CardTitle>
+            <Users className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{tournament!.players.length}</div>
+          </CardContent>
           </Card>
 
           <Card>
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Current Round</CardTitle>
-              <Play className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{tournament.currentRound}</div>
-            </CardContent>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Current Round</CardTitle>
+            <Play className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{tournament!.currentRound}</div>
+          </CardContent>
           </Card>
 
           <Card>
@@ -194,7 +192,7 @@ export default function HomePage() {
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">
-                {tournament.status === "active" ? formatTime(timeRemaining) : "--:--"}
+                {tournament!.status === "active" ? formatTime(timeRemaining) : "--:--"}
               </div>
             </CardContent>
           </Card>
@@ -210,10 +208,10 @@ export default function HomePage() {
           </Card>
         </div>
 
-        {tournament.status === "active" && timeRemaining > 0 && (
+        {tournament!.status === "active" && timeRemaining > 0 && (
           <Card className="border-orange-200 bg-orange-50">
             <CardHeader>
-              <CardTitle className="text-center text-orange-800">Round {tournament.currentRound} in Progress</CardTitle>
+              <CardTitle className="text-center text-orange-800">Round {tournament!.currentRound} in Progress</CardTitle>
             </CardHeader>
             <CardContent>
               <div className="text-center">
@@ -223,8 +221,6 @@ export default function HomePage() {
             </CardContent>
           </Card>
         )}
-      </>
-      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <Card>


### PR DESCRIPTION
## Summary
- remove null check wrapper for main dashboard
- rely on non-null assertions for tournament state

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859afefa2e8832dbddd548458039e6d