### PR TITLE
Fix tournament creation

### DIFF
--- a/app/api/players/route.ts
+++ b/app/api/players/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
 import db from '@/lib/db'
 
+// `better-sqlite3` only works in the Node.js runtime
+export const runtime = 'nodejs'
+
 export async function GET() {
   const rows = db
     .prepare('SELECT data FROM tournaments WHERE id != ?')

--- a/app/api/tournament/route.ts
+++ b/app/api/tournament/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import db from '@/lib/db'
 
+// Use the Node.js runtime since we rely on the `better-sqlite3` package
+export const runtime = 'nodejs'
+
 interface Tournament {
   data: string; // Assuming `data` is a JSON string
 }

--- a/app/api/tournaments/route.ts
+++ b/app/api/tournaments/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
 import db from '@/lib/db'
 
+// Ensure this handler runs in the Node.js runtime
+export const runtime = 'nodejs'
+
 export async function GET() {
   const rows = db.prepare('SELECT id, data FROM tournaments ORDER BY id DESC').all()
   const tournaments = rows.map((row: any) => {

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -52,7 +52,7 @@ export default function SetupPage() {
   const [rounds, setRounds] = useState("4")
   const [timePerRound, setTimePerRound] = useState("50")
 
-  const handleCreateTournament = () => {
+  const handleCreateTournament = async () => {
     if (!tournamentName.trim()) return
 
     const tournament: Tournament = {
@@ -66,13 +66,20 @@ export default function SetupPage() {
       timePerRound: Number.parseInt(timePerRound),
     }
 
-    fetch("/api/tournament", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(tournament),
-    }).then(() => {
-      router.push("/players")
-    })
+    try {
+      const res = await fetch("/api/tournament", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(tournament),
+      })
+      if (res.ok) {
+        router.push("/players")
+      } else {
+        console.error("Failed to create tournament")
+      }
+    } catch (err) {
+      console.error("Failed to create tournament", err)
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- force the Node runtime for database-backed API routes
- handle create tournament errors on the client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859b24bd490832d882a43a0d4e84ce4