### PR TITLE
Fix Netlify build SQLite locking

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -4,6 +4,8 @@ const db = new Database('tournament.db')
 
 // Use Write-Ahead Logging to avoid database locking issues
 db.prepare('PRAGMA journal_mode = WAL').run()
+// Wait for locks to clear instead of immediately failing
+db.pragma('busy_timeout = 5000')
 
 db.prepare(
   `CREATE TABLE IF NOT EXISTS tournaments (


### PR DESCRIPTION
## Summary
- avoid SQLite `database is locked` errors by waiting before failing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859be6c2a54832d9a6a8480bde74b85